### PR TITLE
Move Firebase login creds to .env

### DIFF
--- a/downloadNotes.js
+++ b/downloadNotes.js
@@ -12,8 +12,8 @@ const config = {
   projectId: process.env.REACT_APP_PROJECT_ID,
   storageBucket: process.env.REACT_APP_STORAGE_BUCKET,
   messagingSenderId: process.env.REACT_APP_MESSAGING_SENDER_ID,
-  firebaseEmail: process.env.DOWNLOAD_NOTES_FIREBASE_EMAIL,
-  firebasePassword: process.env.DOWNLOAD_NOTES_FIREBASE_PASS,
+  interviewerEmail: process.env.DOWNLOAD_NOTES_INTERVIEWER_EMAIL,
+  interviewerPassword: process.env.DOWNLOAD_NOTES_INTERVIEWER_PASS,
 };
 
 class Firebase {
@@ -38,7 +38,7 @@ class Firebase {
 
 var stream = fs.createWriteStream(`${moment().format('hh-mm-ss')}.dump.json`, {flags:'a'});
 const firebase = new Firebase();
-firebase.signIn(config.firebaseEmail, config.firebasePassword).then(auth => {
+firebase.signIn(config.interviewerEmail, config.interviewerPassword).then(auth => {
   firebase.interviews().get().then(snapshot => snapshot.forEach(doc => {
     firebase.notes(doc.id).get().then(notes => {
       const temp = {

--- a/downloadNotes.js
+++ b/downloadNotes.js
@@ -12,8 +12,8 @@ const config = {
   projectId: process.env.REACT_APP_PROJECT_ID,
   storageBucket: process.env.REACT_APP_STORAGE_BUCKET,
   messagingSenderId: process.env.REACT_APP_MESSAGING_SENDER_ID,
-  interviewerEmail: process.env.DOWNLOAD_NOTES_INTERVIEWER_EMAIL,
-  interviewerPassword: process.env.DOWNLOAD_NOTES_INTERVIEWER_PASS,
+  interviewerEmail: process.env.INTERVIEWER_EMAIL,
+  interviewerPassword: process.env.INTERVIEWER_PASS,
 };
 
 class Firebase {

--- a/downloadNotes.js
+++ b/downloadNotes.js
@@ -12,6 +12,8 @@ const config = {
   projectId: process.env.REACT_APP_PROJECT_ID,
   storageBucket: process.env.REACT_APP_STORAGE_BUCKET,
   messagingSenderId: process.env.REACT_APP_MESSAGING_SENDER_ID,
+  firebaseEmail: process.env.DOWNLOAD_NOTES_FIREBASE_EMAIL,
+  firebasePassword: process.env.DOWNLOAD_NOTES_FIREBASE_PASS,
 };
 
 class Firebase {
@@ -36,7 +38,7 @@ class Firebase {
 
 var stream = fs.createWriteStream(`${moment().format('hh-mm-ss')}.dump.json`, {flags:'a'});
 const firebase = new Firebase();
-firebase.signIn('upe@bu.edu', 'Interviewer2019').then(auth => {
+firebase.signIn(config.firebaseEmail, config.firebasePassword).then(auth => {
   firebase.interviews().get().then(snapshot => snapshot.forEach(doc => {
     firebase.notes(doc.id).get().then(notes => {
       const temp = {


### PR DESCRIPTION
UPE's interviewer admin creds are stored openly in the download notes script.

This PR adds two new fields to our .env to hide the credentials:
* `DOWNLOAD_NOTES_INTERVIEWER_EMAIL`
* `DOWNLOAD_NOTES_INTERVIEWER_PASS`

This is probably not a big deal because no bots out there will care about logging into our portal. I guess a clever candidate could admin their way into reading the interview questions before their interview though so let's patch this.